### PR TITLE
fix: correct mascot description typo

### DIFF
--- a/404.php
+++ b/404.php
@@ -10,7 +10,7 @@ $dateModified = "2021-06-18";
 
 $imgShare = "share.jpg";
 
-$des = "✓ Petz School. Programas y cursos hechos con amor para tu mascosta.";
+$des = "✓ Petz School. Programas y cursos hechos con amor para tu mascota.";
 
 $tit = "Programas y cursos de Petz School";
 

--- a/contacto.php
+++ b/contacto.php
@@ -8,7 +8,7 @@ $datePublished = "2021-03-24";
 $dateModified = "2021-06-30";
 $imgShare = "share.jpg";
 
-$des = "✓ Petz School. Cursos y programas hechos con amor para tu mascosta.";
+$des = "✓ Petz School. Cursos y programas hechos con amor para tu mascota.";
 $tit = "Petz School - Contacto";
 
 //esto es para si pasamos parametro test no cargamos pixel

--- a/diana-fonseca/index.php
+++ b/diana-fonseca/index.php
@@ -1,4 +1,5 @@
-<?php 
+$des = "✓ Wow mira quien es Diana Fonseca y todos los programas y cursos hechos con amor para tu mascota - Petz School.";
+
 
 header("Cache-Control: no-cache");
 

--- a/index.php
+++ b/index.php
@@ -11,7 +11,7 @@ $dateModified = "2021-06-18";
 $imgShare = "share.jpg";
 
 
-$des = "✓ Petz School. Programas y cursos hechos con amor para tu mascosta.";
+$des = "✓ Petz School. Programas y cursos hechos con amor para tu mascota.";
 $tit = "Programas y cursos de Petz School";
 
 /* esto es para si pasamos parametro test no cargamos pixel */

--- a/programas.php
+++ b/programas.php
@@ -1,4 +1,5 @@
-<?php header("Cache-Control: no-cache");
+$des = "✓ Petz School - Programas hechos con amor para tu mascota.";
+header("Cache-Control: no-cache");
 include "inc/functions.php";
 //$testing = true;
 


### PR DESCRIPTION
## Summary
- correct the typo "mascosta" -> "mascota" in description variables across multiple PHP pages

## Testing
- `npm test` *(fails: Missing script: "test")*