### PR TITLE
Fix webpack extensions list

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -79,7 +79,8 @@ module.exports = (env, argv) => {
             alias: {
                 jquery: path.resolve(__dirname, 'node_modules/jquery/dist/jquery.js')
             },
-            extensions: ['.js', '.jsx', '.scss','css']
+            // Include css files when resolving imports
+            extensions: ['.js', '.jsx', '.scss', '.css']
         },
         mode: 'development' // Or dynamic based on `isProduction`
     };


### PR DESCRIPTION
## Summary
- fix extension entry for webpack resolve

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: webpack not found)*