### PR TITLE
Add PHPUnit tests for getPrecio

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,8 @@
+{
+    "require-dev": {
+        "phpunit/phpunit": "^9.5"
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit"
+    }
+}

--- a/tests/GetPrecioTest.php
+++ b/tests/GetPrecioTest.php
@@ -1,0 +1,41 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+use PHPUnit\Framework\TestCase;
+
+class GetPrecioTest extends TestCase
+{
+    /** @runInSeparateProcess */
+    public function testGetPrecioColombia()
+    {
+        // Prepare environment to skip network calls
+        $_COOKIE['data'] = serialize(['co', 'bogota', 'cundinamarca', 'sa']);
+        $_SERVER['SERVER_NAME'] = 'localhost';
+        $_SERVER['HTTP_HOST'] = 'localhost';
+        $_SERVER['REQUEST_URI'] = '/';
+        $_SERVER['HTTPS'] = 'off';
+        $_SERVER['SERVER_PORT'] = '80';
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+        $_SERVER['HTTP_USER_AGENT'] = 'CLI';
+
+        require __DIR__ . '/../inc/functions.php';
+
+        $this->assertSame('44.000', getPrecio(10));
+    }
+
+    /** @runInSeparateProcess */
+    public function testGetPrecioMexico()
+    {
+        $_COOKIE['data'] = serialize(['mx', 'cdmx', 'mx', 'na']);
+        $_SERVER['SERVER_NAME'] = 'localhost';
+        $_SERVER['HTTP_HOST'] = 'localhost';
+        $_SERVER['REQUEST_URI'] = '/';
+        $_SERVER['HTTPS'] = 'off';
+        $_SERVER['SERVER_PORT'] = '80';
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+        $_SERVER['HTTP_USER_AGENT'] = 'CLI';
+
+        require __DIR__ . '/../inc/functions.php';
+
+        $this->assertSame('240', getPrecio(10));
+    }
+}


### PR DESCRIPTION
## Summary
- add composer.json with phpunit dependency and test script
- create `tests/GetPrecioTest.php` covering `getPrecio` logic for Colombia and Mexico
- require Composer autoloader and call phpunit via vendor script

## Testing
- `composer test` *(fails: composer not installed)*